### PR TITLE
Relocate mobile menu placeholder for better page overlay

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -26,11 +26,11 @@
   <!-- ======================= -->
   <!-- Pop-up Overlay -->
   <div id="pop-up-overlay__placeholder"></div>
-
+  <div id="mobile-menu__placeholder"></div>
   <div id="mainContent">
     <header>
       <div id="navbar__placeholder"></div>
-      <div id="mobile-menu__placeholder"></div>
+   
     </header>
     <main>
       <div class="ticker-container">


### PR DESCRIPTION
Move the `mobile-menu__placeholder` div from inside the `<header>` element to directly after the `pop-up-overlay__placeholder`. This adjustment ensures the mobile menu can overlay the entire page content, including the header, for improved visual presentation and functionality.